### PR TITLE
[Others] BJ_List (1)

### DIFF
--- a/Others/bj_list.py
+++ b/Others/bj_list.py
@@ -1,0 +1,89 @@
+# 공 바꾸기
+def change_a_ball():
+    N,M=map(int,input().split())
+    R=list(range(1,N+1))
+    for _ in [0]*M:
+        i,j=map(int,input().split())
+        R[i-1],R[j-1]=R[j-1],R[i-1]
+    print(*R)
+
+change_a_ball()
+
+# 공 넣기
+def shortest_put_a_ball():
+    p,_,*l=map(int,open(0).read().split())
+    L=[0]*p
+    while l:p,q,r,*l=l;L[p-1:q]=[r]*(q-p+1)
+    print(*L)
+    
+def compact_put_a_ball():
+    N,M=map(int,input().split())
+    R=[0]*(N+1)
+    for _ in [0]*M:
+        i,j,k=map(int,input().split())
+        R[i:j+1]=[k]*(j-i+1)
+    print(*R[1:])
+
+import sys
+def put_a_ball():
+    N, M = [int(i) for i in (sys.stdin.readline().rstrip()).split(' ')]
+
+    basket_dict = {}
+    for i in range(N):
+        basket_dict[i + 1] = '0'
+        
+    order_list = []
+    for i in range(M):
+        order_list.append((sys.stdin.readline().rstrip()))
+
+    for order in order_list:
+        i, j, k = order.split(' ')
+        for n_i in range(int(i), int(j) + 1):
+            basket_dict[n_i] = k
+    
+    print(f"{' '.join(basket_dict.values()).strip(' ')}")
+
+
+# 최댓값
+import sys
+def find_max_value():
+    N_list = []
+    for i in range(9):
+        N_list.append(int(sys.stdin.readline().rstrip()))
+    
+    max_value = max(N_list)
+    print(f"{max_value}")
+    print(f"{N_list.index(max_value) + 1}")
+
+
+# 최소, 최대
+import sys
+def min_max():
+    N_length = int(sys.stdin.readline().rstrip())
+    N_list = [int(i) for i in (sys.stdin.readline().rstrip()).split(' ')]
+
+    print(f"{min(N_list)} {max(N_list)}")
+
+
+# X보다 작은 수
+import sys
+def find_smaller():
+    N_length, X = [int(i) for i in (sys.stdin.readline().rstrip()).split(' ')]
+    N_list = [int(i) for i in (sys.stdin.readline().rstrip()).split(' ')]
+
+    result = []
+    smaller_list = list(map(lambda x:str(x) if x<X else 0, N_list))
+    smaller_list = [str(x) for x in N_list if x < X]
+    while 0 in smaller_list:
+        smaller_list.remove(0)
+    print(' '.join(smaller_list).strip(' '))
+
+
+# 개수 세기
+import sys
+def count_v():
+    N_length = int(sys.stdin.readline().rstrip())
+    N_list = [int(i) for i in (sys.stdin.readline().rstrip()).split(' ')]
+    v = int(sys.stdin.readline().rstrip())
+
+    print(N_list.count(v))


### PR DESCRIPTION
## 배운 점
#### print(*list, sep=' ')
- 파이썬의 * 연산자와 print() 함수의 sep 옵션을 이용하면
' '.join(list) 대체 가능 & for 루프를 돌리거나 pprint 모듈을 임포트하지 않고도, 한 줄의 코드로 처리할 수 있다.
- 원리
1. 우선 배열 앞에 * 연산자를 붙여서 함수를 호출하면 마치 여러 개의 인자를 넘긴 효과가 납니다.
2. 그리고 print() 함수에는 가변 길이의 인자를 넘길 수 있는데요. 기본적으로는 공백을 구분자로 사용합니다.
```
>>> print(1, 2, 3)
1 2 3
```
하지만 sep 옵션으로 이 구분자를 다른 문자로 바꿀 수가 있습니다.
```
>>> print(1, 2, 3, sep=',')
1,2,3
>>> print(1, 2, 3, sep='\n')
1
2
3
```